### PR TITLE
local files and eventual conectivity

### DIFF
--- a/foodandes_app/lib/data/services/local_database_service.dart
+++ b/foodandes_app/lib/data/services/local_database_service.dart
@@ -127,6 +127,37 @@ class LocalDatabaseService {
     return rows.map((r) => r['restaurant_id'] as String).toList();
   }
 
+  Future<Restaurant?> getRestaurantById(String id) async {
+    final db = await _database;
+    final rows = await db.query(
+      'restaurants',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    final row = rows.first;
+    final tagsJson = row['tags_json'] as String? ?? '[]';
+    final tags = (jsonDecode(tagsJson) as List).cast<String>();
+    return Restaurant(
+      id: row['id'] as String,
+      name: row['name'] as String? ?? '',
+      category: row['category'] as String? ?? '',
+      description: '',
+      imageURL: row['image_url'] as String? ?? '',
+      isOpen: (row['is_open'] as int? ?? 0) == 1,
+      latitude: 0.0,
+      longitude: 0.0,
+      openingHours: '',
+      priceRange: row['price_range'] as String? ?? '',
+      rating: (row['rating'] as num?)?.toDouble() ?? 0.0,
+      reviewCount: 0,
+      tags: tags,
+      address: row['address'] as String? ?? '',
+      phone: '',
+    );
+  }
+
   Future<void> clearRestaurants() async {
     final db = await _database;
     await db.delete('restaurants');

--- a/foodandes_app/lib/data/services/user_service.dart
+++ b/foodandes_app/lib/data/services/user_service.dart
@@ -1,7 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:foodandes_app/models/user_profile.dart';
+import 'package:foodandes_app/data/services/local_database_service.dart';
+import 'package:foodandes_app/data/services/lru_cache.dart';
 import 'package:foodandes_app/data/services/restaurant_service.dart';
+import 'package:foodandes_app/models/user_profile.dart';
 
 // FIX #2 + #3:
 // toggleFavoriteRestaurant usaba userRef.update() que lanza si el doc no
@@ -14,47 +16,74 @@ class UserService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
+  // LRU cache for user profiles keyed by userId.
+  // maxSize 10: supports up to 10 distinct users per session (e.g., viewing
+  // other users' profiles in a social feature). User profiles rarely change,
+  // so a cache hit avoids a Firestore read on every ProfileScreen open.
+  final LruCache<String, UserProfile> _profileCache = LruCache(maxSize: 10);
+
   String? get _uid => _auth.currentUser?.uid;
 
   Future<UserProfile?> getCurrentUserProfile() async {
-    if (_uid == null) return null;
+    final uid = _uid;
+    if (uid == null) return null;
 
+    // 1. Check LRU cache first — avoids Firestore read if already loaded.
+    final cached = _profileCache.get(uid);
+    if (cached != null) return cached;
+
+    // 2. Fetch from Firestore and store in LRU before returning.
     try {
       final doc = await _firestore
           .collection('users')
-          .doc(_uid)
+          .doc(uid)
           .get()
           .timeout(const Duration(seconds: 8));
 
       if (!doc.exists || doc.data() == null) return null;
-      return UserProfile.fromFirestore(doc.id, doc.data()!);
+      final profile = UserProfile.fromFirestore(doc.id, doc.data()!);
+      _profileCache.put(uid, profile);
+      return profile;
     } catch (_) {
       return null;
     }
   }
 
   Future<List<String>> getFavoriteRestaurantIds() async {
-    if (_uid == null) return [];
+    final uid = _uid;
+    if (uid == null) return [];
+
+    // Reuse the profile cache — favorites are part of the UserProfile document,
+    // so if the profile is already cached we avoid a second Firestore read.
+    final cached = _profileCache.get(uid);
+    if (cached != null) return cached.favoriteRestaurants;
 
     try {
       final doc = await _firestore
           .collection('users')
-          .doc(_uid)
+          .doc(uid)
           .get()
           .timeout(const Duration(seconds: 8));
 
       final data = doc.data();
       if (data == null) return [];
-      return List<String>.from(data['favoriteRestaurants'] ?? []);
+
+      // Cache the full profile so subsequent calls to getCurrentUserProfile()
+      // also benefit from this read.
+      final profile = UserProfile.fromFirestore(doc.id, data);
+      _profileCache.put(uid, profile);
+
+      return profile.favoriteRestaurants;
     } catch (_) {
       return [];
     }
   }
 
   Future<void> toggleFavoriteRestaurant(String restaurantId) async {
-    if (_uid == null) throw Exception('No authenticated user');
+    final uid = _uid;
+    if (uid == null) throw Exception('No authenticated user');
 
-    final userRef = _firestore.collection('users').doc(_uid);
+    final userRef = _firestore.collection('users').doc(uid);
     final snapshot = await userRef.get();
     final data = snapshot.data() ?? {};
 
@@ -72,7 +101,25 @@ class UserService {
       SetOptions(merge: true),
     );
 
-    // Invalida caché para que el cambio se vea inmediatamente
+    // Invalidate both caches so the next read reflects the updated favorites.
+    _profileCache.remove(uid);
     RestaurantService.instance.invalidateCache();
+
+    // Sync to local SQLite so FavoritesScreen can show saved favorites offline.
+    try {
+      final db = LocalDatabaseService.instance;
+      if (favorites.contains(restaurantId)) {
+        await db.insertFavorite(uid, restaurantId);
+      } else {
+        await db.removeFavorite(uid, restaurantId);
+      }
+    } catch (_) {}
+  }
+
+  /// Removes the cached profile for the current user.
+  /// Call this after any profile update (name, photo, dietary preferences).
+  void invalidateProfileCache() {
+    final uid = _uid;
+    if (uid != null) _profileCache.remove(uid);
   }
 }

--- a/foodandes_app/lib/features/favorites/favorites_screen.dart
+++ b/foodandes_app/lib/features/favorites/favorites_screen.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:foodandes_app/data/repositories/restaurant_repository.dart';
+import 'package:foodandes_app/data/services/connectivity_service.dart';
+import 'package:foodandes_app/data/services/local_database_service.dart';
 import 'package:foodandes_app/features/favorites/favorites_empty_screen.dart';
 import 'package:foodandes_app/features/restaurant/restaurant_detail_screen.dart';
 import 'package:foodandes_app/models/restaurant.dart';
 import 'package:foodandes_app/shared/widgets/custom_bottom_navbar.dart';
+import 'package:foodandes_app/shared/widgets/offline_protected_notice.dart';
 import 'package:foodandes_app/shared/widgets/restaurant_card.dart';
 import 'package:foodandes_app/data/services/analytics_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -19,6 +24,12 @@ class FavoritesScreen extends StatefulWidget {
 }
 
 class _FavoritesScreenState extends State<FavoritesScreen> {
+  final RestaurantRepository _repository = RestaurantRepository();
+
+  late Future<List<Restaurant>> _favoritesFuture;
+  bool _isOffline = false;
+  StreamSubscription<bool>? _connectivitySubscription;
+
   Future<void> _logFavoritesInteraction(
     String action, {
     Map<String, Object>? additionalParameters,
@@ -32,18 +43,15 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     );
   }
 
-  final RestaurantRepository _repository = RestaurantRepository();
-
-  late Future<List<Restaurant>> _favoritesFuture;
-
   @override
   void initState() {
     super.initState();
-    _loadFavorites();
+    // Optimistic default: assume online until connectivity check completes.
+    _favoritesFuture = _repository.fetchFavoriteRestaurants();
+    _initConnectivity();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final userId = FirebaseAuth.instance.currentUser?.uid;
-
       AnalyticsService.instance.logSectionView(
         section: AppSection.favorites,
         userId: userId,
@@ -51,11 +59,63 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     });
   }
 
+  Future<void> _initConnectivity() async {
+    final online = await ConnectivityService.instance.isOnline;
+    if (!mounted) return;
+    setState(() {
+      _isOffline = !online;
+      _loadFavorites();
+    });
+
+    _connectivitySubscription =
+        ConnectivityService.instance.isOnlineStream.listen((isOnline) {
+      if (!mounted) return;
+      setState(() {
+        _isOffline = !isOnline;
+        _loadFavorites();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _connectivitySubscription?.cancel();
+    super.dispose();
+  }
+
   void _loadFavorites() {
-    _favoritesFuture = _repository.fetchFavoriteRestaurants();
+    _favoritesFuture = _isOffline
+        ? _loadFavoritesFromLocal()
+        : _repository.fetchFavoriteRestaurants();
+  }
+
+  Future<List<Restaurant>> _loadFavoritesFromLocal() async {
+    final userId = FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return [];
+
+    final results = await Future.wait<dynamic>([
+      LocalDatabaseService.instance.getRestaurants(),
+      LocalDatabaseService.instance.getFavoriteIds(userId),
+    ]);
+
+    final allRestaurants = results[0] as List<Restaurant>;
+    final favoriteIds = results[1] as List<String>;
+
+    return allRestaurants
+        .where((r) => favoriteIds.contains(r.id))
+        .map((r) => r.copyWith(isFavorite: true))
+        .toList();
   }
 
   Future<void> _toggleFavorite(Restaurant restaurant) async {
+    if (_isOffline) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Cannot change favorites while offline')),
+      );
+      return;
+    }
+
     final userId = FirebaseAuth.instance.currentUser?.uid;
     final willBeFavorite = !restaurant.isFavorite;
 
@@ -117,49 +177,70 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
 
         final favorites = snapshot.data ?? [];
 
-        if (favorites.isEmpty) {
+        if (favorites.isEmpty && !_isOffline) {
           return const FavoritesEmptyScreen();
         }
 
         return Scaffold(
-          appBar: AppBar(
-            title: const Text('My Favorites'),
-          ),
+          appBar: AppBar(title: const Text('My Favorites')),
           bottomNavigationBar: const CustomBottomNavbar(currentIndex: 3),
           body: ListView(
             padding: const EdgeInsets.all(16),
             children: [
-              Text(
-                '${favorites.length} saved restaurants',
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 16),
-              ...favorites.map(
-                (restaurant) => Padding(
-                  padding: const EdgeInsets.only(bottom: 18),
-                  child: RestaurantCard(
-                    restaurant: restaurant,
-                    showFavoriteIcon: true,
-                    favoriteFilled: true,
-                    onFavoriteTap: () => _toggleFavorite(restaurant),
-                    onTap: () async {
-                      await _logFavoritesInteraction(
-                        'open_favorite_restaurant',
-                        additionalParameters: {'restaurant_id': restaurant.id},
-                      );
-                      await Navigator.pushNamed(
-                        context,
-                        RestaurantDetailScreen.routeName,
-                        arguments: restaurant.id,
-                      );
-
-                      setState(() {
-                        _loadFavorites();
-                      });
-                    },
+              if (_isOffline)
+                const Padding(
+                  padding: EdgeInsets.only(bottom: 16),
+                  child: OfflineProtectedNotice(
+                    message: 'Offline mode · showing saved favorites',
                   ),
                 ),
-              ),
+              if (favorites.isEmpty)
+                const Center(
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 48),
+                    child: Text(
+                      'No saved favorites found locally',
+                      style: TextStyle(fontSize: 16),
+                    ),
+                  ),
+                )
+              else ...[
+                Text(
+                  '${favorites.length} saved restaurants',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16),
+                ...favorites.map(
+                  (restaurant) => Padding(
+                    padding: const EdgeInsets.only(bottom: 18),
+                    child: RestaurantCard(
+                      restaurant: restaurant,
+                      showFavoriteIcon: true,
+                      favoriteFilled: true,
+                      onFavoriteTap: () => _toggleFavorite(restaurant),
+                      onTap: () async {
+                        await _logFavoritesInteraction(
+                          'open_favorite_restaurant',
+                          additionalParameters: {
+                            'restaurant_id': restaurant.id,
+                          },
+                        );
+                        if (!context.mounted) return;
+                        await Navigator.pushNamed(
+                          context,
+                          RestaurantDetailScreen.routeName,
+                          arguments: restaurant.id,
+                        );
+
+                        if (!mounted) return;
+                        setState(() {
+                          _loadFavorites();
+                        });
+                      },
+                    ),
+                  ),
+                ),
+              ],
             ],
           ),
         );

--- a/foodandes_app/lib/features/restaurant/restaurant_detail_screen.dart
+++ b/foodandes_app/lib/features/restaurant/restaurant_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:foodandes_app/core/constants/app_colors.dart';
 import 'package:foodandes_app/core/utils/map_launcher_helper.dart';
 import 'package:foodandes_app/data/repositories/restaurant_repository.dart';
+import 'package:foodandes_app/data/services/local_database_service.dart';
 import 'package:foodandes_app/features/restaurant/compare_restaurants_screen.dart';
 import 'package:foodandes_app/features/restaurant/reviews_screen.dart';
 import 'package:foodandes_app/models/restaurant.dart';
@@ -28,11 +29,25 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
 
   String? _restaurantId;
   Future<Restaurant?>? _restaurantFuture;
-  bool _hasLoggedRestaurantView = false;
   String? _lastLoggedRestaurantId;
+  bool _servedFromLocal = false;
 
   Future<Restaurant?> _fetchRestaurant(String restaurantId) async {
-    return _repository.fetchRestaurantById(restaurantId);
+    _servedFromLocal = false;
+
+    // Try primary path: LRU cache → list cache → Firestore.
+    final restaurant = await _repository.fetchRestaurantById(restaurantId);
+    if (restaurant != null) return restaurant;
+
+    // Fall back to SQLite when offline or Firestore is unreachable.
+    final local =
+        await LocalDatabaseService.instance.getRestaurantById(restaurantId);
+    if (local != null) {
+      _servedFromLocal = true;
+      return local;
+    }
+
+    return null;
   }
 
   @override
@@ -41,11 +56,10 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
 
     final restaurantId = ModalRoute.of(context)?.settings.arguments as String?;
 
-  if (restaurantId != null && restaurantId != _restaurantId) {
-    _restaurantId = restaurantId;
-    _hasLoggedRestaurantView = false;
-    _loadRestaurant();
-}
+    if (restaurantId != null && restaurantId != _restaurantId) {
+      _restaurantId = restaurantId;
+      _loadRestaurant();
+    }
   }
 
   void _loadRestaurant() {
@@ -162,6 +176,10 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
 
           return ListView(
             children: [
+              if (_servedFromLocal)
+                const OfflineProtectedNotice(
+                  message: 'Offline mode · showing last saved version',
+                ),
               Stack(
                 children: [
                   AspectRatio(
@@ -382,6 +400,7 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
                                 'restaurant_id': restaurant.id,
                               },
                             );
+                            if (!context.mounted) return;
                             await Navigator.pushNamed(
                               context,
                               ReviewsScreen.routeName,
@@ -424,6 +443,7 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
                                 'restaurant_id': restaurant.id,
                               },
                             );
+                            if (!context.mounted) return;
                             await Navigator.pushNamed(
                               context,
                               CompareRestaurantsScreen.routeName,


### PR DESCRIPTION
Offline support & protected views
Adds full offline resilience to three screens and completes the local caching pipeline.

What changed:

FavoritesScreen and RestaurantDetailScreen now load from SQLite when offline instead of showing an error — joining HomeScreen as protected views
UserService gained an LRU cache for user profiles (maxSize: 10), avoiding redundant Firestore reads on every profile/favorites fetch
toggleFavoriteRestaurant now mirrors every change to the local user_favorites SQLite table, keeping offline favorites in sync
LocalDatabaseService gained getRestaurantById(id) for O(1) single-record lookups by primary key
Fixed pre-existing BuildContext async gap warnings in RestaurantDetailScreen