### PR TITLE
search_history_feature

### DIFF
--- a/foodandes_app/lib/data/services/local_database_service.dart
+++ b/foodandes_app/lib/data/services/local_database_service.dart
@@ -21,7 +21,7 @@ class LocalDatabaseService {
     final path = join(dbPath, 'restaurandes.db');
     return openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE restaurants (
@@ -44,6 +44,22 @@ class LocalDatabaseService {
             PRIMARY KEY(user_id, restaurant_id)
           )
         ''');
+        await db.execute('''
+          CREATE TABLE search_history (
+            query TEXT PRIMARY KEY,
+            searched_at INTEGER NOT NULL
+          )
+        ''');
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS search_history (
+              query TEXT PRIMARY KEY,
+              searched_at INTEGER NOT NULL
+            )
+          ''');
+        }
       },
     );
   }
@@ -161,5 +177,46 @@ class LocalDatabaseService {
   Future<void> clearRestaurants() async {
     final db = await _database;
     await db.delete('restaurants');
+  }
+
+  Future<void> insertSearchQuery(String query) async {
+    final db = await _database;
+    await db.insert(
+      'search_history',
+      {'query': query, 'searched_at': DateTime.now().millisecondsSinceEpoch},
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+    // Keep only the 10 most recent unique queries
+    await db.rawDelete('''
+      DELETE FROM search_history
+      WHERE query NOT IN (
+        SELECT query FROM search_history ORDER BY searched_at DESC LIMIT 10
+      )
+    ''');
+  }
+
+  Future<List<String>> getSearchHistory() async {
+    final db = await _database;
+    final rows = await db.query(
+      'search_history',
+      columns: ['query'],
+      orderBy: 'searched_at DESC',
+      limit: 10,
+    );
+    return rows.map((r) => r['query'] as String).toList();
+  }
+
+  Future<void> deleteSearchQuery(String query) async {
+    final db = await _database;
+    await db.delete(
+      'search_history',
+      where: 'query = ?',
+      whereArgs: [query],
+    );
+  }
+
+  Future<void> clearSearchHistory() async {
+    final db = await _database;
+    await db.delete('search_history');
   }
 }

--- a/foodandes_app/lib/data/services/search_history_service.dart
+++ b/foodandes_app/lib/data/services/search_history_service.dart
@@ -1,0 +1,21 @@
+import 'package:foodandes_app/data/services/local_database_service.dart';
+
+class SearchHistoryService {
+  SearchHistoryService._();
+  static final SearchHistoryService instance = SearchHistoryService._();
+  factory SearchHistoryService() => instance;
+
+  final LocalDatabaseService _db = LocalDatabaseService.instance;
+
+  Future<void> save(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return;
+    await _db.insertSearchQuery(trimmed);
+  }
+
+  Future<List<String>> getAll() => _db.getSearchHistory();
+
+  Future<void> delete(String query) => _db.deleteSearchQuery(query);
+
+  Future<void> clear() => _db.clearSearchHistory();
+}

--- a/foodandes_app/lib/features/search/search_empty_screen.dart
+++ b/foodandes_app/lib/features/search/search_empty_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:foodandes_app/data/repositories/restaurant_repository.dart';
+import 'package:foodandes_app/data/services/search_history_service.dart';
 import 'package:foodandes_app/features/restaurant/restaurant_detail_screen.dart';
 import 'package:foodandes_app/models/restaurant.dart';
 import 'package:foodandes_app/shared/widgets/custom_bottom_navbar.dart';
@@ -22,12 +23,14 @@ class SearchEmptyScreen extends StatefulWidget {
 
 class _SearchEmptyScreenState extends State<SearchEmptyScreen> {
   final RestaurantRepository _repository = RestaurantRepository();
+  final SearchHistoryService _historyService = SearchHistoryService.instance;
   final TextEditingController _searchController = TextEditingController();
 
   late Future<List<Restaurant>> _allRestaurantsFuture;
 
   List<Restaurant> _allRestaurants = [];
   List<Restaurant> _filteredRestaurants = [];
+  List<String> _searchHistory = [];
   bool _isLoadingRestaurants = true;
   Timer? _searchAnalyticsDebounce;
   String _lastTrackedQuery = '';
@@ -36,6 +39,7 @@ class _SearchEmptyScreenState extends State<SearchEmptyScreen> {
   void initState() {
     super.initState();
     _loadRestaurants();
+    _loadHistory();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final userId = FirebaseAuth.instance.currentUser?.uid;
@@ -45,6 +49,27 @@ class _SearchEmptyScreenState extends State<SearchEmptyScreen> {
         userId: userId,
       );
     });
+  }
+
+  Future<void> _loadHistory() async {
+    final history = await _historyService.getAll();
+    if (!mounted) return;
+    setState(() => _searchHistory = history);
+  }
+
+  Future<void> _deleteHistoryItem(String query) async {
+    await _historyService.delete(query);
+    await _loadHistory();
+  }
+
+  Future<void> _clearHistory() async {
+    await _historyService.clear();
+    await _loadHistory();
+  }
+
+  void _applyHistoryQuery(String query) {
+    _searchController.text = query;
+    _onSearchChanged(query);
   }
 
   Future<void> _logSearchInteraction(
@@ -157,6 +182,40 @@ class _SearchEmptyScreenState extends State<SearchEmptyScreen> {
     super.dispose();
   }
 
+  Widget _buildSearchHistory() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text(
+              'Recent searches',
+              style: TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+            ),
+            TextButton(
+              onPressed: _clearHistory,
+              child: const Text('Clear all'),
+            ),
+          ],
+        ),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: _searchHistory.map((query) {
+            return InputChip(
+              label: Text(query),
+              avatar: const Icon(Icons.history, size: 16),
+              deleteIcon: const Icon(Icons.close, size: 16),
+              onDeleted: () => _deleteHistoryItem(query),
+              onPressed: () => _applyHistoryQuery(query),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final query = _searchController.text.trim();
@@ -180,12 +239,14 @@ class _SearchEmptyScreenState extends State<SearchEmptyScreen> {
                   const SizedBox(height: 16),
                   Expanded(
                     child: !hasQuery
-                        ? const EmptyStateWidget(
-                            icon: Icons.search,
-                            title: 'Start typing to search',
-                            subtitle:
-                                'Find restaurants by name, category, tag, or address',
-                          )
+                        ? _searchHistory.isEmpty
+                            ? const EmptyStateWidget(
+                                icon: Icons.search,
+                                title: 'Start typing to search',
+                                subtitle:
+                                    'Find restaurants by name, category, tag, or address',
+                              )
+                            : _buildSearchHistory()
                         : _filteredRestaurants.isEmpty
                             ? const EmptyStateWidget(
                                 icon: Icons.search_off,
@@ -212,14 +273,17 @@ class _SearchEmptyScreenState extends State<SearchEmptyScreen> {
                                         onFavoriteTap: () =>
                                             _toggleFavorite(restaurant),
                                         onTap: () async {
+                                          final nav = Navigator.of(context);
+                                          await _historyService.save(
+                                            _searchController.text,
+                                          );
                                           await _logSearchInteraction(
                                             'open_search_result',
                                             additionalParameters: {
                                               'restaurant_id': restaurant.id,
                                             },
                                           );
-                                          await Navigator.pushNamed(
-                                            context,
+                                          await nav.pushNamed(
                                             RestaurantDetailScreen.routeName,
                                             arguments: restaurant.id,
                                           );


### PR DESCRIPTION
Add search history with SQLite persistence

Stores the last 10 unique search queries in a local SQLite table (DB migration v1→v2). Shows recent searches as dismissible chips on the search screen when no query is active; saves a query when the user taps a result.